### PR TITLE
Resolve Corrupted RPM Database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ rm -f /lib/systemd/system/basic.target.wants/*;\
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 # Install requirements.
-RUN yum -y install \
+RUN dnf -y install rpm centos-release && \
+    dnf -y install \
       epel-release \
       initscripts \
       sudo \


### PR DESCRIPTION
The CentOS guys need to rebuild their image so that updates don't
apply later and corrupt their base image.

This fix seems to work for me.

Fix #7

Signed-off-by: David Brown <dmlb2000@gmail.com>