### PR TITLE
Use lowercase to specify a repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ rm -f /lib/systemd/system/anaconda.target.wants/*;
 # Install requirements.
 RUN yum -y install rpm centos-release dnf-plugins-core \
  && yum -y update \
- && yum -y config-manager --set-enabled PowerTools \
+ && yum -y config-manager --set-enabled powertools \
  && yum -y install \
       epel-release \
       initscripts \


### PR DESCRIPTION
The name of a repository must be specified as lowercase.

```
[root@9a0248d8193d yum.repos.d]# cat CentOS-Linux-PowerTools.repo
# CentOS-Linux-PowerTools.repo
#
# The mirrorlist system uses the connecting IP address of the client and the
# update status of each mirror to pick current mirrors that are geographically
# close to the client.  You should use this for CentOS updates unless you are
# manually picking other mirrors.
#
# If the mirrorlist does not work for you, you can try the commented out
# baseurl line instead.

[powertools]
name=CentOS Linux $releasever - PowerTools
mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=PowerTools&infra=$infra
#baseurl=http://mirror.centos.org/$contentdir/$releasever/PowerTools/$basearch/os/
gpgcheck=1
enabled=0
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
```

Otherwise the build will fail with an error message like:

```
...
Error: No matching repo to modify: PowerTools.
The command '/bin/sh -c yum -y install rpm centos-release dnf-plugins-core  && yum -y update  && yum -y config-manager --set-enabled PowerTools  && yum -y install       epel-release       initscripts       sudo       which       hostname       libyaml-devel       python3       python3-pip       python3-pyyaml  && yum clean all' returned a non-zero code: 1
```